### PR TITLE
mcb-gitdoc - Added GitHub documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,132 @@ To-do
 ## How do I report an issue with SOP materials?
 
 To-do
+
+## Summary diagram
+````mermaid
+flowchart TB
+    %% Colors
+    classDef SOP fill:#FFD700,stroke:#000000,stroke-width:2px;
+    classDef Template fill:#87CEEB,stroke:#000000,stroke-width:2px;
+
+    %% Nodes    
+    D -->|Yes| E
+    F[General GDI SOP Template]
+    F -->|Is used by| E
+    K -->|Identifies the need for a\n new Node-specific GDI SOP| E
+    E[T4.3/WP4]
+    E -->|Prepares template| G
+    G[SOP Template]
+    G --> H
+    H[T4.3/WP4]
+    H -->|Shares template| I
+    
+
+    %% Boxes
+    subgraph European-level SOPs
+        A[GDI project partners]
+        A -->|Identify the need for a\n new European level GDI SOP| B
+        B[GDI project partners]
+        B -->|Write proposal of SOP.\n inc. purpose, scope, and justification of SOP| C
+        C[Relevant 1+MG Working group]
+        C --> D
+        D{Approves\nproposal?}
+        D -->|No| B
+        S[SOP Instance]
+        V[Finished European-level\nSOP Instance]
+        ZA[Released European-level\nSOP Instance]
+    end
+
+    ZA -->|Enters periodic\nreview cycle| ZA
+
+    subgraph Node-specific SOPs
+        direction TB
+        K[T4.3/WP4]
+        Q[SOP Template]
+        W[Finished Node-specific\nSOP Template]
+        Z[Released Node-specific\nSOP Template]
+        nodeRep[OC/SDPC Representatives\nfrom each node]
+        Z -->|is used by| nodeRep
+        subgraph Node's-GitHub
+            nodeTem[Node-specific\nSOP Template]
+            nodeSOP[Node-specific\nSOP Instance]
+        end
+        nodeRep -->|Copy SOP Template| Node's-GitHub
+        subgraph Node's-Roles
+            nodeRep[Node's OC/SDPC representative]
+            nodeRep --> |Nominate| nodeExp
+            nodeExp[Node's experts]
+        end
+        subgraph Node's-SOP-development-process
+            nodeDev(Template gets adapted\n with the node's needs)
+            nodeDev --> nodeRev
+            nodeRev(Review)
+            nodeRev --> nodeApp
+            nodeApp(Approval)
+            nodeApp --> nodeAcc
+            nodeAcc(Accessioning)
+        end
+        Node's-Roles -..->|Responsible for| Node's-SOP-development-process        
+        nodeTem --> nodeDev
+        nodeApp --> |Produces| nodeSOP
+    end
+
+    subgraph Authors
+        I[Operations Committee - OC\nSecurity and Data Protection Committee - SDPC]
+        I -->|Nominate|J
+        J[Nominated experts]
+    end
+
+    I --> |Start development process| R
+    Authors -..-> |Fill SOP content| L
+    P -..->|Review SOP| M
+    T -..->|Approve SOP|N
+    U -..->|Authorize SOP| O
+    R{Is SOP\na template?}
+    R -->|Yes| Q
+    R -->|No| S
+    Q -->|Enters cycle|SOP-development-cycle
+    S -->|Enters cycle|SOP-development-cycle
+
+    subgraph SOP-development-cycle
+        L(Content-filling)
+        L --> M
+        M(Review)
+        M --> N
+        N(Approval)
+        N --> O
+        O(Authorization)
+        O --> zz(Finished Development cycle)
+    end
+    zz -->|Produces| V
+    zz -->|Produces| W
+    
+    subgraph ORR-roles
+        Authors
+        P[Reviewers]
+        T[Approvers]
+        U[Authorizers\ne.g. Management Board - MB\ne.g. 1+MG Working Group]
+    end
+
+    V -->|Enters process| SOP-release-process
+    W -->|Enters process| SOP-release-process
+    SOP-release-process -->|Produces| ZA
+    SOP-release-process -->|Produces| Z
+
+    I -..->|Responsible for| SOP-release-process
+    subgraph SOP-release-process
+        Accessioning(SOP Accessioning)
+        Accessioning --> GitHub-management
+        GitHub-management
+    end
+
+    subgraph GitHub-management
+        git1(Pull Request\nto main branch\nwith new SOP)
+        git1 --> git2
+        git2(PR approved)
+    end
+
+    %% Styles
+    class G,S,V,ZA,nodeSOP SOP
+    class F,Q,W,Z,nodeTem Template
+````

--- a/README.md
+++ b/README.md
@@ -21,11 +21,18 @@ flowchart TB
     classDef SOP fill:#FFD700,stroke:#000000,stroke-width:2px;
     classDef Template fill:#87CEEB,stroke:#000000,stroke-width:2px;
 
-    %% Nodes    
+    %% Nodes
+    A[GDI project partners]
+    A -->|Identify the need for a\n new European level GDI SOP| B
+    B[GDI project partners]
+    B -->|Write proposal of SOP.\n inc. purpose, scope, and justification of SOP| B2
+    B2[GitHub Issue]
+    B2 --> D
+    D{1+MG Working\nGroup Approves\nproposal?}
+    D -->|No| B
     D -->|Yes| E
     F[General GDI SOP Template]
     F -->|Is used by| E
-    K -->|Identifies the need for a\n new Node-specific GDI SOP| E
     E[T4.3/WP4]
     E -->|Prepares template| G
     G[SOP Template]
@@ -36,14 +43,6 @@ flowchart TB
 
     %% Boxes
     subgraph European-level SOPs
-        A[GDI project partners]
-        A -->|Identify the need for a\n new European level GDI SOP| B
-        B[GDI project partners]
-        B -->|Write proposal of SOP.\n inc. purpose, scope, and justification of SOP| C
-        C[Relevant 1+MG Working group]
-        C --> D
-        D{Approves\nproposal?}
-        D -->|No| B
         S[SOP Instance]
         V[Finished European-level\nSOP Instance]
         ZA[Released European-level\nSOP Instance]
@@ -52,8 +51,6 @@ flowchart TB
     ZA -->|Enters periodic\nreview cycle| ZA
 
     subgraph Node-specific SOPs
-        direction TB
-        K[T4.3/WP4]
         Q[SOP Template]
         W[Finished Node-specific\nSOP Template]
         Z[Released Node-specific\nSOP Template]
@@ -139,6 +136,6 @@ flowchart TB
     end
 
     %% Styles
-    class G,S,V,ZA,nodeSOP SOP
-    class F,Q,W,Z,nodeTem Template
+    class S,V,ZA,nodeSOP SOP
+    class G,F,Q,W,Z,nodeTem Template
 ````

--- a/docs/github-management.md
+++ b/docs/github-management.md
@@ -1,0 +1,106 @@
+# Copying GDI SOP repository
+The GDI SOP repository ([**GenomicDataInfrastructure/standard-operating-procedures**](https://github.com/GenomicDataInfrastructure/standard-operating-procedures)) contains both European-level SOP _instances_ and Node-specific SOP _templates_. In order to adapt the Node-specific SOP templates, GDI nodes are expected to make a copy of this GitHub repository and modify them to suit them to their needs.
+
+Given that the base repository is public, forks of this repository cannot be private. Therefore, making a node's copy of the repository can be done in different ways, explained in this document, depending on the level of privacy that each node may require:
+- **Public node's repository**. If the node does not require for a private repository, copying the source repository is straightforward. See section _[1. Public repository](./github-management.md#1-public-repository)_.
+- **Private node's repository**. On the contrary, if nodes need their SOP instances to be private (e.g. for security reasons), an alternative route is taken. See section _[2. Private repository](./github-management.md#2-private-repository)_.
+
+````mermaid
+flowchart TD
+    A[Source Repository] 
+    dec{Node's repo\nprivacy}
+    A --> dec
+    dec -->|Public| B(Fork public repository)
+    dec -->|Private| C(Import)    
+    H[Work with node's\n repository]
+    F --> H
+    B --> H[Work with node's\n repository]
+    subgraph Public Path
+        B
+    end
+    subgraph Private Path
+        C(Import) --> E(Add Upstream Remote)
+        E --> G(Disable Push to Upstream)
+        E --> F(Sync with Upstream)
+    end
+````
+
+## 1. Public repository
+Here, we provide step-by-step instructions for **forking** a GitHub repository using GitHub's user interface.
+
+### 1.1 Creating a fork repository
+
+1. Open [GitHub](https://github.com/) and log in to your account.
+1. Go to [GDI SOP repository](https://github.com/GenomicDataInfrastructure/standard-operating-procedures) page.
+1. Click the "Fork" button in the upper-right corner of the repository page.
+1. Provide the details of your forked repository: 
+    - Choose as owner your GitHub account or organization to create the fork. This repository will be your node's instance of the ``standard-operating-procedures``. Therefore, we recommend you to use your organization's namespace (similar to [GenomicDataInfrastructure](https://github.com/GenomicDataInfrastructure) but for your specific organization), as the repository ``Owner``, instead of your own username. 
+    - Provide the name and description that you see fit. We recommend to use the default ones.
+1. Click on "Create fork" and wait a few moments.
+
+### 1.2 Work with Your Fork
+1. Navigate to your forked repository. It will have your username or organization name at the beginning of the URL (``https://github.com/<your-username>/standard-operating-procedures``).
+1. Clone the fork to your local machine:
+    ````bash
+    git clone https://github.com/<your-username>/standard-operating-procedures.git
+    cd standard-operating-procedures
+    ````
+    Remember to replace ``<your-username>`` with the correct name.
+1. Start making changes to the existing SOP Templates, the [node-specific](../sops/node-specific/), creating your node's instance of the SOPs to make them useful for your node.
+
+## 2. Private repository
+
+This rubric guides project partners through the steps to create a private repository from a public GitHub repository and maintain synchronization with the original source.
+
+### 2.1 Create a Private Repository
+
+1. Open [GitHub](https://github.com/) and log in to your account.
+1. Click on "[New Repository](https://github.com/new)".
+1. Click on "[Import a repository](https://github.com/new/import)".
+1. Follow the instructions to import a repository:
+    1. Enter the URL of the **source repository**:
+        ```markdown
+        https://github.com/GenomicDataInfrastructure/standard-operating-procedures
+        ```
+    1. Enter the details of the **new repository**. 
+        - This repository will be your node's instance of the ``standard-operating-procedures``. Therefore, we recommend you to use your organization's namespace (similar to [GenomicDataInfrastructure](https://github.com/GenomicDataInfrastructure) but for your specific organization), as the repository ``Owner``, instead of your own username. 
+        - You can choose any name for the new repository (recommended: ``standard-operating-procedures``)
+        - Choose "Private" as your new repository's privacy level. Otherwise, we advise you to follow section _[1. Public repository](./github-management.md#1-public-repository)_.
+    
+        Since the source repository is public, no credentials are needed to copy it.
+1. Click "Begin Import". Wait for a few moments while GitHub imports the repository.
+
+### 2.3 Add Upstream Remote and Disable Pushing
+Once your repository has been imported, we are ready to set the source repository as the upstream remote. This is for your repository (called ``origin``) to track changes in the source repository (called ``upstream``):
+1. **Clone your new private repository** to your local machine:
+    ````bash
+    git clone https://github.com/<your-username>/standard-operating-procedures.git
+    cd standard-operating-procedures
+    ````
+    Remember to replace ``<your-username>`` with either your organization's namespace or your GitHub username, whichever you used as "Owner" when importing.
+1. Add the public repository as an upstream remote:
+    ````bash
+    git remote add upstream https://github.com/GenomicDataInfrastructure/standard-operating-procedures.git
+    ````
+1. Disable pushing to the upstream repository to avoid accidental changes to the public repository:
+    ````bash
+    git remote set-url --push upstream no_push
+    ````
+
+### 2.4 Sync with Upstream
+Whenever there are changes in the source repository, you can sync your node's repository:
+1. Fetch updates from the public repository (upstream):
+    ````bash
+    git fetch upstream
+    ````
+1. Merge or rebase the changes from the upstream repository. If there are conflicts, we advise you to resolve them them manually.
+    1. Merge:
+        ````bash
+        git merge upstream/main --no-edit
+        ````
+    1. Rebase:
+        ````bash
+        git rebase upstream/main
+        ````
+### 2.5 Work with your private copy
+You are ready to make any changes the existing SOP Templates, the [node-specific](../sops/node-specific/), creating your node's instance of the SOPs to make them useful for your node.

--- a/docs/github-management.md
+++ b/docs/github-management.md
@@ -33,7 +33,7 @@ Here, we provide step-by-step instructions for **forking** a GitHub repository u
 1. Open [GitHub](https://github.com/) and log in to your account.
 1. Go to [GDI SOP repository](https://github.com/GenomicDataInfrastructure/standard-operating-procedures) page.
 1. Click the "Fork" button in the upper-right corner of the repository page.
-1. Provide the details of your forked repository: 
+1. Provide the details of your **forked repository**: 
     - Choose as owner your GitHub account or organization to create the fork. This repository will be your node's instance of the ``standard-operating-procedures``. Therefore, we recommend you to use your organization's namespace (similar to [GenomicDataInfrastructure](https://github.com/GenomicDataInfrastructure) but for your specific organization), as the repository ``Owner``, instead of your own username. 
     - Provide the name and description that you see fit. We recommend to use the default ones.
 1. Click on "Create fork" and wait a few moments.
@@ -45,12 +45,12 @@ Here, we provide step-by-step instructions for **forking** a GitHub repository u
     git clone https://github.com/<your-username>/standard-operating-procedures.git
     cd standard-operating-procedures
     ````
-    Remember to replace ``<your-username>`` with the correct name.
-1. Start making changes to the existing SOP Templates, the [node-specific](../sops/node-specific/), creating your node's instance of the SOPs to make them useful for your node.
+    Remember to replace ``<your-username>`` with the name that you used as "Owner" when forking.
+1. **Start making changes to the existing SOP Templates**, the [node-specific](../sops/node-specific/), creating your node's instance of the SOPs to make them useful for your node.
 
 ## 2. Private repository
 
-This rubric guides project partners through the steps to create a private repository from a public GitHub repository and maintain synchronization with the original source.
+This rubric guides project partners through the steps to create a **private repository from a public GitHub repository** and maintain synchronization with the original source.
 
 ### 2.1 Create a Private Repository
 
@@ -71,29 +71,38 @@ This rubric guides project partners through the steps to create a private reposi
 1. Click "Begin Import". Wait for a few moments while GitHub imports the repository.
 
 ### 2.3 Add Upstream Remote and Disable Pushing
-Once your repository has been imported, we are ready to set the source repository as the upstream remote. This is for your repository (called ``origin``) to track changes in the source repository (called ``upstream``):
+Once your repository has been imported, we are ready to **set the source repository as the upstream remote**. This is for your repository (called ``origin``) to track changes in the source repository (called ``upstream``):
 1. **Clone your new private repository** to your local machine:
     ````bash
     git clone https://github.com/<your-username>/standard-operating-procedures.git
     cd standard-operating-procedures
     ````
     Remember to replace ``<your-username>`` with either your organization's namespace or your GitHub username, whichever you used as "Owner" when importing.
-1. Add the public repository as an upstream remote:
+1. Add the **public repository as an upstream remote**:
     ````bash
     git remote add upstream https://github.com/GenomicDataInfrastructure/standard-operating-procedures.git
     ````
-1. Disable pushing to the upstream repository to avoid accidental changes to the public repository:
+1. **Disable pushing to the upstream repository** to avoid accidental changes to the public repository:
     ````bash
-    git remote set-url --push upstream no_push
+    git remote set-url --push upstream DISABLE
     ````
 
+If everything was correctly set, you should see something similar to the following:
+````bash
+$ git remote -v
+origin  git@github.com:<your-username>/standard-operating-procedures.git (fetch)
+origin  git@github.com:<your-username>/standard-operating-procedures.git (push)
+upstream        https://github.com/GenomicDataInfrastructure/standard-operating-procedures.git (fetch)
+upstream        DISABLE (push)
+````
+
 ### 2.4 Sync with Upstream
-Whenever there are changes in the source repository, you can sync your node's repository:
-1. Fetch updates from the public repository (upstream):
+Whenever there are changes in the source repository, you can **sync your node's repository**:
+1. **Fetch updates** from the public repository (upstream):
     ````bash
     git fetch upstream
     ````
-1. Merge or rebase the changes from the upstream repository. If there are conflicts, we advise you to resolve them them manually.
+1. **Merge or rebase** the changes from the upstream repository. If there are conflicts, we advise you to resolve them them manually.
     1. Merge:
         ````bash
         git merge upstream/main --no-edit


### PR DESCRIPTION
In order to make the node's adaptation of GDI GitHub repository easier, I added documentation explaining both how to make a public fork and a private repository from the public SOP repository.