### PR TITLE
Quick diagram fix - update "+" sign interpreted as markdown

### DIFF
--- a/docs/GDI-SOP_sop-accessioning.md
+++ b/docs/GDI-SOP_sop-accessioning.md
@@ -75,9 +75,9 @@ flowchart TB
             sopt_m2("`**Identifier**: GDI-SOP0001.v1`")
         end
     end
-    sopt_m1 -->|+| sopt
-    title1 -->|+| sopt
-    sopt_m2 -..->|+| sopt
+    sopt_m1 -->|#43;| sopt
+    title1 -->|#43;| sopt
+    sopt_m2 -..->|#43;| sopt
     sopt -->|Node adapts template| sopi
 
     subgraph Node's-GitHub
@@ -87,12 +87,11 @@ flowchart TB
             sopi_m2("`**Identifier**: GDI-SOP0001.v1_SWE.v1`")
         end
     end
-    sopi_m2 -..->|+|sopi
+    sopi_m2 -..->|#43;| sopi
 
     %% Styles
     class sopt Template
     class sopi SOP
-
 ````
 
 ### Supporting documents


### PR DESCRIPTION
<!--- Thank you for taking the time to contribute to this project! -->
<!--- Provide a general summary of your changes in the Title above -->

## Summary
After recent updates of mermaid and markdown in GH, the sign ``+`` as literal was interpreted as a list starter in markdown, rendering wrongly the diagrams in the SOP accessioning document. 

## Types of changes
<!--- Mention the type of contribution this PR represents: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New content (non-breaking change which adds new content)
- [ ] Modified content (non-breaking change which modifies existing content)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Motivation and Context
It was wrongly rendered
### References
NA

## Changes Introduced
- Swapped the ``+`` literal for its encoding ``#43;``

## Review
None, just checked in the branch and locally. After that, no review truly is needed for a small fix.

## Additional Notes
NA

## Checklist:
<!--- Review carefully, ticking (or adding an `x` to) each box  upon completion of the item, ensuring you meet the standards required for this PR. -->

**General Compliance:**
- [x] My changes follow the code style of this project ([GDI SOP Style Guide](https://github.com/GenomicDataInfrastructure/standard-operating-procedures/blob/main/docs/GDI-SOP_style-guide.md)) and the file naming conventions of the [file accessioning proposal](https://github.com/GenomicDataInfrastructure/standard-operating-procedures/blob/main/docs//GDI-SOP_sop-accessioning.md).
- [x] I have verified that all new updated content is accessible, including checking that all external references are readable (i.e., no broken links). These may include references to external resources that should be resolvable, and internal references among SOPs.
- [x] I have properly added this PR's changes to the repository [CHANGELOG.md](../CHANGELOG.md).

Only applicable if the PR includes new, or changes to, GDI SOPs (i.e., documents at ``sops/``):
- [ ] My SOP-related changes adhere to the [Generic SOP Template](https://github.com/GenomicDataInfrastructure/standard-operating-procedures/blob/main/docs/GDI-SOP_sop-template.md), including format and required fields.
- [ ] I have consulted the [Charter](https://github.com/GenomicDataInfrastructure/standard-operating-procedures/blob/main/docs/GDI-SOP_charter.md), [ISM](https://github.com/GenomicDataInfrastructure/standard-operating-procedures/blob/main/docs/GDI-SOP_information-service-management.md), and [ORR](https://github.com/GenomicDataInfrastructure/standard-operating-procedures/blob/main/docs/GDI-SOP_organisational-roles-and-responsibilities.md) documents to ensure compliance. 
- [ ] I am complying with the established procedure for SOP creations and modifications, including respecting review phases and notifying needed contributors for reviews.
